### PR TITLE
[15.0][IMP] l10n_es_aeat_mod_303: Eliminar codigo muerto para evitar confusion con funcionalidad permitida

### DIFF
--- a/l10n_es_aeat_mod303/README.rst
+++ b/l10n_es_aeat_mod303/README.rst
@@ -127,6 +127,8 @@ Contributors
   * Antonio Espinosa
   * Luis M. Ontalba
   * Pedro M. Baeza
+  * Sergio Teruel
+  * Carlos Dauden
 * `Sygel <https://www.sygel.es>`__:
 
   * Harald Panten

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -303,35 +303,6 @@ class L10nEsAeatMod303Report(models.Model):
             else:
                 record.marca_sepa = "0"
 
-    # pylint:disable=missing-return
-    @api.depends("date_start", "cuota_compensar")
-    def _compute_exception_msg(self):
-        super(L10nEsAeatMod303Report, self)._compute_exception_msg()
-        for mod303 in self.filtered(lambda x: x.state != "draft"):
-            # Get result from previous declarations, in order to identify if
-            # there is an amount to compensate.
-            prev_reports = mod303._get_previous_fiscalyear_reports(
-                mod303.date_start
-            ).filtered(lambda x: x.state not in ["draft", "cancelled"])
-            if not prev_reports:
-                continue
-            prev_report = min(
-                prev_reports,
-                key=lambda x: abs(
-                    fields.Date.to_date(x.date_end)
-                    - fields.Date.to_date(mod303.date_start)
-                ),
-            )
-            if prev_report.result_type == "C" and not mod303.cuota_compensar:
-                if mod303.exception_msg:
-                    mod303.exception_msg += "\n"
-                else:
-                    mod303.exception_msg = ""
-                mod303.exception_msg += _(
-                    "In previous declarations this year you reported a "
-                    "Result Type 'To Compensate'. You might need to fill "
-                    "field '[67] Fees to compensate' in this declaration."
-                )
 
     @api.depends("company_id", "result_type")
     def _compute_counterpart_account_id(self):

--- a/l10n_es_aeat_mod303/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod303/readme/CONTRIBUTORS.rst
@@ -7,6 +7,8 @@
   * Antonio Espinosa
   * Luis M. Ontalba
   * Pedro M. Baeza
+  * Sergio Teruel
+  * Carlos Dauden
 * `Sygel <https://www.sygel.es>`__:
 
   * Harald Panten

--- a/l10n_es_aeat_mod303/static/description/index.html
+++ b/l10n_es_aeat_mod303/static/description/index.html
@@ -481,6 +481,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Antonio Espinosa</li>
 <li>Luis M. Ontalba</li>
 <li>Pedro M. Baeza</li>
+<li>Sergio Teruel</li>
+<li>Carlos Dauden</li>
+
 </ul>
 </li>
 <li><a class="reference external" href="https://www.sygel.es">Sygel</a>:<ul>


### PR DESCRIPTION
@Tecnativa