### PR TITLE
[IMP] l10n_es_aeat_mod303: Return last period, fix result type computation

### DIFF
--- a/l10n_es_aeat_mod303/README.rst
+++ b/l10n_es_aeat_mod303/README.rst
@@ -138,6 +138,7 @@ Contributors
   * Iván Antón
 
 * Arantxa Sudón (`Moduon <https://www.moduon.team/>`__)
+* Rafael Blasco (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -473,10 +473,12 @@ class L10nEsAeatMod303Report(models.Model):
                 else:
                     report.result_type = "I"
             else:
-                if report.devolucion_mensual or report.period_type in ("4T", "12"):
+                if report.devolucion_mensual or (
+                    report.period_type in ("4T", "12") and report.return_last_period
+                ):
                     if report.use_aeat_account:
                         report.result_type = "V"
-                    elif report.return_last_period:
+                    else:
                         report.result_type = "D" if report.marca_sepa == "1" else "X"
                 else:
                     report.result_type = "C"

--- a/l10n_es_aeat_mod303/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod303/readme/CONTRIBUTORS.rst
@@ -16,3 +16,4 @@
   * Iván Antón
 
 * Arantxa Sudón (`Moduon <https://www.moduon.team/>`__)
+* Rafael Blasco (`Moduon <https://www.moduon.team/>`__)

--- a/l10n_es_aeat_mod303/static/description/index.html
+++ b/l10n_es_aeat_mod303/static/description/index.html
@@ -495,6 +495,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Arantxa Sudón (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
+<li>Rafael Blasco (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -34,6 +34,10 @@
             <field name="previous_number" position="after">
                 <field name="devolucion_mensual" />
                 <field
+                    name="return_last_period"
+                    attrs="{'invisible': [('period_type', 'not in', ('4T', '12'))]}"
+                />
+                <field
                     name="exonerated_390"
                     attrs="{'invisible': [('period_type', 'not in', ('4T', '12'))]}"
                 />


### PR DESCRIPTION
@EmilioPascual @Jesarregui @JordiBForgeFlow

He hecho un fix para el problema detectado en el PR #3534. 
En algunos casos se quedaba en campo return_last_period (computed) sin valor asignado y esto causaba el error.